### PR TITLE
Release 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Contributions are welcome! I don't have grand ambitions with this script, but if
 
 # Changelog
 
+### 2.1.0 (2023/07/16)
+added button to enable toggling A3 content on demand (contributed by [@robert-vo](https://github.com/robert-vo) - thanks!)
+
 ### 2.0.0 (2023/07/14)
 moved from a Gist to a proper GitHub repo! _Please re-sync your script with the updated @updateURL/@downloadURL directives to continue getting updates._
 

--- a/script.js
+++ b/script.js
@@ -112,6 +112,9 @@ class A3ContentController {
 
         this.elementsToToggle = new Array();
 
+        // Manually include the "Insufficient Data" row: all A20 PLUS content is ranked, so don't render an empty row
+        this.elementsToToggle.push($("#no-rating-row"));
+
         // ALL_SONG_DATA contains an array of song data structured like {song_id, song_name, version_num}, etc:
         // Find all the song jackets that map to DDR A3 (version_num === 19) for toggling.
         let newSongs = songData.filter(e => e.version_num == 19);
@@ -164,7 +167,4 @@ class A3ContentController {
     // Install the A3 toggle button under the "What's this list?" link in the top right
     let link = document.querySelector("#explanation")
     link.parentNode.insertBefore(button, link.nextSibling);
-
-    // always hide the 'Insufficient Data' row for cleanliness - iirc, A20 PLUS songs are all ranked
-    $("#no-rating-row").hide();
 })();

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         3icecream difficulty_list - only MDX:U songs
 // @namespace    https://vyhd.dev
-// @version      2.0.0
+// @version      2.1.0
 // @description  Removes songs from 3icecream's tier lists that are unavailable on MDX:U (A20 PLUS, white) cabs.
 // @license      CC0-1.0; https://creativecommons.org/publicdomain/zero/1.0/
 // @author       vyhd@vyhd.dev


### PR DESCRIPTION
* added button to enable toggling A3 content on demand
* refactoring to cache song jacket lookup, making toggling ~80-90% faster (yay, slapdash `performance.now()` benchmarking)