### PR TITLE
Remove challenge charts that are licenses

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,9 +46,7 @@ const MANUAL_REVOCATION_LIST = [
 
     // other A3 Challenge charts
     {song_id: "o9P816l0QQ1b9l1l6i1o6OD9bl9dP00l", difficulties: CSP_AND_CDP}, // BITTER CHOCOLATE STRIKER
-    {song_id: "o1d0DDobPPPlq0l8Qli1d6ODI8ldo1qb", difficulties: CSP_AND_CDP}, // シル・ヴ・プレジデント
     {song_id: "6dO6i9qq601D8ild9QIlbO8bodbiQ1Pl", difficulties: CSP_AND_CDP}, // 灼熱Beach Side Bunny
-    {song_id: "PIP1OIoObQ11Q0Po6idiloqOl9OQqqdd", difficulties: CSP_AND_CDP}, // なだめスかし Negotiation
 
     // A20 gold cab exclusive songs
     {song_id: "6dQQd1d1OQlqQdQ98i01DQ1i9P6QDQdQ"}, // BUTTERFLY (20th Anniversary Mix)


### PR DESCRIPTION
If these challenge chart removals also appear in the "new restricted licenses" section, this will toggle 4 and 8 off, but then when the script goes and redoes these songs for the licenses entry it will toggle every difficulty (which will include toggling difficulties 0-3 and 5-7 off but then toggle 4 and 8 on). This should fix the bug!